### PR TITLE
feat: create drt SDK method

### DIFF
--- a/src/app/utils/sdk/createTransactions/dataPoolOperationTxns.ts
+++ b/src/app/utils/sdk/createTransactions/dataPoolOperationTxns.ts
@@ -1,0 +1,87 @@
+import algosdk from 'algosdk';
+
+// create unsigned transaction DEMO until the enclave can create their own transactions
+export const createCreateDRTTxn = async (
+  appID: number | bigint,
+  client: algosdk.Algodv2,
+  creator: { addr: string },
+  drtName: string,
+  drtSupply: number | bigint,
+  drtPrice: number | bigint,
+  drtUrlBinary: string,
+  drtBinaryHash: string
+) => {
+  try {
+    const contractAddr = algosdk.getApplicationAddress(appID);
+    const appArgs = [
+      new Uint8Array(Buffer.from('create_drt')),
+      new Uint8Array(Buffer.from(drtName)),
+      new Uint8Array(Buffer.from(algosdk.encodeUint64(drtSupply))),
+      new Uint8Array(Buffer.from(drtUrlBinary)),
+      new Uint8Array(Buffer.from(drtBinaryHash)),
+      new Uint8Array(Buffer.from(algosdk.encodeUint64(drtPrice)))
+    ];
+    const params = await client.getTransactionParams().do();
+
+    const onComplete = algosdk.OnApplicationComplete.NoOpOC;
+
+    params.fee = 1000;
+    params.flatFee = true;
+
+    const txn = algosdk.makeApplicationCallTxnFromObject({
+      from: creator.addr,
+      appIndex: Number(appID),
+      suggestedParams: params,
+      onComplete: onComplete,
+      appArgs: appArgs,
+      accounts: [creator.addr]
+    });
+
+    return txn;
+  } catch (err) {
+    console.log(err);
+  }
+};
+
+export const createClaimDRTTxn = async (
+  appID: number | bigint,
+  client: algosdk.Algodv2,
+  creator: { addr: string },
+  drtID: number | bigint
+) => {
+  try {
+    const contractAddr = algosdk.getApplicationAddress(appID);
+    const appArgs = [new Uint8Array(Buffer.from('drt_to_box'))];
+    const params = await client.getTransactionParams().do();
+
+    const onComplete = algosdk.OnApplicationComplete.NoOpOC;
+
+    params.fee = 1000;
+    params.flatFee = true;
+
+    const assetBytes = algosdk.encodeUint64(drtID);
+    const pk = algosdk.decodeAddress(contractAddr).publicKey;
+    var boxName = new Uint8Array(assetBytes.length + pk.length);
+    boxName.set(assetBytes);
+    boxName.set(pk, assetBytes.length);
+
+    const txn = algosdk.makeApplicationCallTxnFromObject({
+      from: creator.addr,
+      appIndex: Number(appID),
+      suggestedParams: params,
+      onComplete: onComplete,
+      appArgs: appArgs,
+      foreignAssets: [Number(drtID)],
+      boxes: [
+        {
+          appIndex: Number(appID),
+          name: boxName
+        }
+      ]
+    });
+
+    return txn;
+  } catch (err) {
+    console.log(err);
+  }
+};

--- a/src/app/utils/sdk/methods/dataPoolOperations.ts
+++ b/src/app/utils/sdk/methods/dataPoolOperations.ts
@@ -1,0 +1,59 @@
+import algosdk from 'algosdk';
+
+import {
+  createClaimDRTTxn,
+  createCreateDRTTxn
+} from '../createTransactions/dataPoolOperationTxns';
+import {
+  sendClaimDRTTxn,
+  sendCreateDRTTxn
+} from '../sendTransactions/sendDataPoolTxns';
+
+const createDRTMethod = async (
+  creatorAccount: algosdk.Account,
+  appID: number | bigint,
+  client: algosdk.Algodv2,
+  drtName: string,
+  drtSupply: number | bigint,
+  drtPrice: number | bigint,
+  drtUrlBinary: string,
+  drtBinaryHash: string
+) => {
+  try {
+    /// Transaction 1 - Create DRT
+    let txn1 = await createCreateDRTTxn(
+      appID,
+      client,
+      creatorAccount,
+      drtName,
+      drtSupply,
+      drtPrice,
+      drtUrlBinary,
+      drtBinaryHash
+    );
+
+    const txId_1 = await txn1?.txID().toString();
+
+    // Sign the transaction, here we have to intervene
+    const creatorSecret = creatorAccount?.sk;
+    const signedtxn1 = txn1?.signTxn(creatorSecret);
+    // pai(username, password, signedTxn)
+    // intervene above with authenticateion
+
+    const drtID = await sendCreateDRTTxn(signedtxn1, client, txId_1!, appID);
+    const txn2 = await createClaimDRTTxn(appID, client, creatorAccount, drtID);
+    const txId_2 = await txn2?.txID().toString();
+
+    // Sign the transaction, here we have to intervene
+    const signedtxn2 = txn2?.signTxn(creatorSecret);
+    // pai(username, password, signedTxn)
+    // intervene above with authenticateion
+
+    const result = await sendClaimDRTTxn(signedtxn2, client, txId_2!);
+    return drtID;
+  } catch (err) {
+    console.log(err);
+  }
+};
+
+export { createDRTMethod };

--- a/src/app/utils/sdk/sendTransactions/sendDataPoolTxns.ts
+++ b/src/app/utils/sdk/sendTransactions/sendDataPoolTxns.ts
@@ -1,4 +1,43 @@
-const path = require('path');
-const fs = require('fs');
-const algosdk = require('algosdk');
-const assert = require('assert');
+import algosdk from 'algosdk';
+
+export const sendCreateDRTTxn = async (
+  signedTxn: any,
+  client: algosdk.Algodv2,
+  txId: string,
+  appID: any
+) => {
+  try {
+    const contractAddr = algosdk.getApplicationAddress(appID);
+
+    await client.sendRawTransaction(signedTxn).do();
+    // Wait for transaction to be confirmed
+    const confirmedTxn = await algosdk.waitForConfirmation(client, txId, 4);
+
+    const transactionResponse = await client
+      .pendingTransactionInformation(txId)
+      .do();
+    const drtID = transactionResponse['inner-txns'][0]['asset-index'];
+    return drtID;
+  } catch (err) {
+    console.log(err);
+  }
+};
+
+export const sendClaimDRTTxn = async (
+  signedTxn: any,
+  client: algosdk.Algodv2,
+  txId: string
+) => {
+  try {
+    await client.sendRawTransaction(signedTxn).do();
+    // Wait for transaction to be confirmed
+    const confirmedTxn = await algosdk.waitForConfirmation(client, txId, 4);
+
+    const transactionResponse = await client
+      .pendingTransactionInformation(txId)
+      .do();
+    return transactionResponse;
+  } catch (err) {
+    console.log(err);
+  }
+};

--- a/tests/sdk.test.ts
+++ b/tests/sdk.test.ts
@@ -1,5 +1,6 @@
 import algosdk, { getApplicationAddress } from 'algosdk';
 import { createDataPoolMethod } from '../src/app/utils/sdk/methods/createPool';
+import { createDRTMethod } from '../src/app/utils/sdk/methods/dataPoolOperations';
 
 test('Testnet: Smart Contract Creation ', async () => {
   // setup client to testnet
@@ -86,4 +87,17 @@ test('Testnet: Smart Contract Creation ', async () => {
     '\nCreators Contributor Token ID: ',
     dataPool?.contributorCreatorID
   );
+
+  console.log('\nCreate DRT for Data Pool');
+  const drtID = await createDRTMethod(
+    creatorAccount,
+    dataPool?.appID,
+    client,
+    'testDRT',
+    10,
+    1000000,
+    'drt_binary',
+    'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+  );
+  console.log('DRT Created: ', drtID);
 }, 300000);


### PR DESCRIPTION
### Create DRT JS-SDK
This feature creates the transactions to Create a DRT represented on the algorand blockchain network as a ASA (algo standard asset).
This feature includes the create DRT method that includes the following transactions:
- create DRT
- claim DRT ( store DRT in box storage ) 

### Test
Testing is done by creating fake accounts and signing the transactions without the imported signing functionality from the wallet.

setup local sandbox and run
run in terminal `npm run test-sdk -- tests/sdk.test.ts --verbose`